### PR TITLE
Update spatial.cu

### DIFF
--- a/spatial.cu
+++ b/spatial.cu
@@ -12,10 +12,19 @@
 #include "spatial.h"
 #include "simple_knn.h"
 
+#include <cuda_runtime.h>  // Include the CUDA runtime header for cudaSetDevice()
+
 torch::Tensor
 distCUDA2(const torch::Tensor& points)
 {
   const int P = points.size(0);
+
+  // Determine which device the tensor is on
+  auto device = points.device();
+  int device_index = device.index(); // Get the index of the device
+
+  // Set the current CUDA device to the device where 'points' is located
+  cudaSetDevice(device_index);
 
   auto float_opts = points.options().dtype(torch::kFloat32);
   torch::Tensor means = torch::full({P}, 0.0, float_opts);


### PR DESCRIPTION
Solved a problem that the distCUDA2 not work on CUDA devices other than "cuda:0".

Solution:
1) Detects the CUDA device which the input tensor is on
2) Set the current CUDA device to the corresponding device