### PR TITLE
add header for FLT_MAX

### DIFF
--- a/ext.cpp
+++ b/ext.cpp
@@ -3,7 +3,7 @@
  * GRAPHDECO research group, https://team.inria.fr/graphdeco
  * All rights reserved.
  *
- * This software is free for non-commercial, research and evaluation use 
+ * This software is free for non-commercial, research and evaluation use
  * under the terms of the LICENSE.md file.
  *
  * For inquiries contact  george.drettakis@inria.fr

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 # GRAPHDECO research group, https://team.inria.fr/graphdeco
 # All rights reserved.
 #
-# This software is free for non-commercial, research and evaluation use 
+# This software is free for non-commercial, research and evaluation use
 # under the terms of the LICENSE.md file.
 #
 # For inquiries contact  george.drettakis@inria.fr
@@ -24,7 +24,7 @@ setup(
         CUDAExtension(
             name="simple_knn._C",
             sources=[
-            "spatial.cu", 
+            "spatial.cu",
             "simple_knn.cu",
             "ext.cpp"],
             extra_compile_args={"nvcc": [], "cxx": cxx_compiler_flags})

--- a/simple_knn.cu
+++ b/simple_knn.cu
@@ -3,7 +3,7 @@
  * GRAPHDECO research group, https://team.inria.fr/graphdeco
  * All rights reserved.
  *
- * This software is free for non-commercial, research and evaluation use 
+ * This software is free for non-commercial, research and evaluation use
  * under the terms of the LICENSE.md file.
  *
  * For inquiries contact  george.drettakis@inria.fr

--- a/simple_knn.cu
+++ b/simple_knn.cu
@@ -17,6 +17,7 @@
 #include <cub/cub.cuh>
 #include <cub/device/device_radix_sort.cuh>
 #include <vector>
+#include <float.h>
 #include <cuda_runtime_api.h>
 #include <thrust/device_vector.h>
 #include <thrust/sequence.h>

--- a/simple_knn.h
+++ b/simple_knn.h
@@ -3,7 +3,7 @@
  * GRAPHDECO research group, https://team.inria.fr/graphdeco
  * All rights reserved.
  *
- * This software is free for non-commercial, research and evaluation use 
+ * This software is free for non-commercial, research and evaluation use
  * under the terms of the LICENSE.md file.
  *
  * For inquiries contact  george.drettakis@inria.fr

--- a/spatial.cu
+++ b/spatial.cu
@@ -3,7 +3,7 @@
  * GRAPHDECO research group, https://team.inria.fr/graphdeco
  * All rights reserved.
  *
- * This software is free for non-commercial, research and evaluation use 
+ * This software is free for non-commercial, research and evaluation use
  * under the terms of the LICENSE.md file.
  *
  * For inquiries contact  george.drettakis@inria.fr
@@ -28,7 +28,7 @@ distCUDA2(const torch::Tensor& points)
 
   auto float_opts = points.options().dtype(torch::kFloat32);
   torch::Tensor means = torch::full({P}, 0.0, float_opts);
-  
+
   SimpleKNN::knn(P, (float3*)points.contiguous().data<float>(), means.contiguous().data<float>());
 
   return means;

--- a/spatial.h
+++ b/spatial.h
@@ -3,7 +3,7 @@
  * GRAPHDECO research group, https://team.inria.fr/graphdeco
  * All rights reserved.
  *
- * This software is free for non-commercial, research and evaluation use 
+ * This software is free for non-commercial, research and evaluation use
  * under the terms of the LICENSE.md file.
  *
  * For inquiries contact  george.drettakis@inria.fr


### PR DESCRIPTION
Since CUDA 12.5, the macro 'FLT_MAX' is missing. See https://github.com/pytorch/audio/pull/3811. The fix is to include header 'float.h' with the same definition.