### PR TITLE
include torch.h instead of extension.h

### DIFF
--- a/spatial.h
+++ b/spatial.h
@@ -9,6 +9,6 @@
  * For inquiries contact  george.drettakis@inria.fr
  */
 
-#include <torch/extension.h>
+#include <torch/torch.h>
 
 torch::Tensor distCUDA2(const torch::Tensor& points);


### PR DESCRIPTION
Including `<torch/torch.h>` should be sufficient for simple-knn, there isn't a need to include `<torch/extension.h>`. The motivation of this change is that `<torch/extension.h>` indirectly includes "Python.h" and is causing all sorts of unnecessary cmake troubles when using this repo as a submodule for my C++ project.

Additionally, `pip install git+https://github.com/miriameng/simple-knn` is successful.