### PR TITLE
Add `*.so` to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 build/
 simple_knn.egg-info/
 dist/
-simple_knn/_C.cpython-310-x86_64-linux-gnu.so
+simple_knn/*.so

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 build/
 simple_knn.egg-info/
 dist/
+simple_knn/_C.cpython-310-x86_64-linux-gnu.so


### PR DESCRIPTION
Hi,

This PR adds *.so to the .gitignore file.

After building the project, a .so file is generated but not ignored by default. When this repository is used as a Git submodule in other projects, this can result in an always-dirty state (e.g., a blue dot in some IDEs), which is slightly annoying during development.

This small change ensures that generated shared object files won’t show up as untracked changes anymore. It doesn't affect any currently tracked binaries.

Thanks for maintaining this project!

Best,
Rui